### PR TITLE
Fix submodule link to BinaryData

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "BinaryData"]
 	path = BinaryData
-	url = https://github.com/Syroot/BinaryData.git
+	url = https://gitlab.com/Syroot/BinaryData.git
 [submodule "commandline"]
 	path = commandline
 	url = https://github.com/gsscoder/commandline.git


### PR DESCRIPTION
BinaryData's repository [moved to GitLab](https://archive.softwareheritage.org/browse/origin/directory/?origin_url=https://github.com/Syroot/BinaryData), which broke the submodule.